### PR TITLE
Add missing Lua headers to lua_errno.h

### DIFF
--- a/src/lua_errno.h
+++ b/src/lua_errno.h
@@ -24,6 +24,9 @@
 #define lua_errno_h
 
 // lualib
+#include <lauxlib.h>
+#include <lua.h>
+// lua_error
 #include <lua_error.h>
 
 #define LUA_ERRNO_T_DEFAULT "errno.new"


### PR DESCRIPTION
This pull request makes a small update to the `src/lua_errno.h` header file by adding missing include directives for Lua headers. This helps ensure the file has access to necessary Lua types and functions.

* Added `#include <lauxlib.h>` and `#include <lua.h>` to the top of `src/lua_errno.h` to properly include Lua core and auxiliary library definitions.